### PR TITLE
feat: extend commitlint config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,22 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'style',
+        'chore',
+        'refactor',
+        'perf',
+        'test',
+        'docs',
+        'cleanup',
+        'revert',
+        'content'
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
Extends the commitlint config to use a custom array of prefixes, all of which are still defined per the conventional commit standard, except with the addition of `content:`

This is fed into the husky pre-commit check.