### PR TITLE
style: slow sidebar text marquee

### DIFF
--- a/components/card.vue
+++ b/components/card.vue
@@ -227,7 +227,7 @@ export default {
         position: absolute;
         bottom: 0;
         pointer-events: none;
-        animation: sidebarTextScroll 20s linear infinite paused;
+        animation: sidebarTextScroll 40s linear infinite paused;
         display: block;
       }
     }


### PR DESCRIPTION
This PR just contains a minor style change slowing down the marquee on the card sidebars by 50%