### PR TITLE
fix: sync initial slide order

### DIFF
--- a/components/section-collaborators.vue
+++ b/components/section-collaborators.vue
@@ -138,7 +138,7 @@ export default {
   computed: {
     collaborators () {
       const array = []
-      for (let i = 0; i < 3; i++) { array.push(this.logos) }
+      for (let i = 0; i < 2; i++) { array.push(this.logos) }
       return array.flat()
     }
   }

--- a/components/sliders/circular-slider-b.vue
+++ b/components/sliders/circular-slider-b.vue
@@ -136,8 +136,10 @@ export default {
   data () {
     const len = this.collection.length
     const num = this.stacked ? 1 : this.displayOptions.default
+    const pos = [...Array(len).keys()]
+    for (let i = 0; i < 2; i++) { pos.unshift(pos.pop()) }
     return {
-      positions: [...Array(len).keys()],
+      positions: pos,
       animateSlots: new Array(num + 2).fill(null).map((e, i) => i + 1),
       display: num,
       columnWidth: 0,

--- a/content/core/index.json
+++ b/content/core/index.json
@@ -599,8 +599,6 @@
             "name": "SectionCollaborators",
             "props": {
               "logos": [
-                "/images/digital-mob-logo.svg",
-                "/images/keyko-logo.svg",
                 "/images/filecoin-foundation-logo.svg",
                 "/images/daghouse-logo.svg",
                 "/images/undone-ventures-logo.svg",
@@ -608,7 +606,9 @@
                 "/images/starboard-logo.svg",
                 "/images/togggle-logo.svg",
                 "/images/eqtylab-logo.svg",
-                "/images/laudspeaker-logo.svg"
+                "/images/laudspeaker-logo.svg",
+                "/images/digital-mob-logo.svg",
+                "/images/keyko-logo.svg"
               ],
               "ctablock": {
                 "marquee_text": "WORK WITH US WORK WITH US WORK WITH US WORK WITH US",


### PR DESCRIPTION
A fix to sync the order that logos appear in json content with initial slide positions in the `circular-slider-b` component.


Ticket link:

https://www.notion.so/agencyundone/contributors-logos-should-show-up-in-order-listed-in-json-665d5feb9cfa4df9a5e66a6d54c43113?pvs=4

Ticket number: AU-2728